### PR TITLE
Add the capability to use Mustache templates at compile time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rack-single-page-app.gemspec
 gemspec
+
+group :development, :test do
+  gem 'mustache'
+end

--- a/README.md
+++ b/README.md
@@ -22,15 +22,25 @@ gem 'rack-single-page-app', :require => 'rack/single_page_app'
 
 ## Configuration
 
-### Rack
+### Static Index Page
 
-In `config.ru`, configure `Rack::SinglePageApp` by passing the destination file to the constructor:
+In `config.ru`, configure `Rack::SinglePageApp::Index` by passing the destination file to the constructor:
 
 ```ruby
-run Rack::SinglePageApp.new("public/index.html")
+run Rack::SinglePageApp::Index.new("public/index.html")
 ```
 
 Generally, you'll run `Rack::Static` higher up in your `config.ru` so that you deliver static assets prior to single-page-app fall-through.
+
+### Mustache Templates
+
+Use `Rack::SinglePageApp::Template` to compile the static output from a Mustache template. Pass the path to the template and a context object to the constructor:
+
+```ruby
+run Rack::SinglePageApp::Index.new("templates/index.html", context)
+```
+
+Note that this template will be compiled once in-memory when the app starts up, and the content will be static for the lifetime of the app.
 
 ### Testing
 

--- a/lib/rack/single_page_app.rb
+++ b/lib/rack/single_page_app.rb
@@ -2,25 +2,63 @@ require 'rack'
 require 'git-version-bump'
 
 module Rack
-  # Rack::SinglePageApp is a default endpoint. Initialize with the path to
-  # your index page.
-
-  class SinglePageApp
-    F = ::File
-
+  module SinglePageApp
     def self.release
       GVB.version
     end
 
-    def initialize(path)
-      file = F.expand_path(path)
-      @content = F.read(file)
-      @length = @content.size.to_s
+    F = ::File
+
+    # The base Rack application which sends default HTML content.
+    class Base
+      # @param content [String] Response body content
+      def initialize(content)
+        @content = content
+        @length = @content.size.to_s
+      end
+
+      def call(env)
+        [200, {'Content-Type' => 'text/html', 'Content-Length' => @length}, [@content]]
+      end
     end
 
-    def call(env)
-      [200, {'Content-Type' => 'text/html', 'Content-Length' => @length}, [@content]]
+    # Respond to generic server requests with a static HTML index page.
+    #
+    # @example
+    #   run Rack::SinglePageApp::Index('assets/index.html')
+    #
+    class Index < Base
+      # @param path [String] Path to static file
+      def initialize(path)
+        file = F.expand_path(path)
+        super(F.read(file))
+      end
+    end
+
+    # Respond to generic server requests with a Mustache template, rendered with
+    # the provided context.
+    #
+    # Mustache is an optional dependency, so needs to be required before this
+    # object is constructed.
+    #
+    # @example
+    #   require 'mustache'
+    #
+    #   context = {
+    #     title: "App Title",
+    #     body_class: "app-layout app-layout-fixed-width",
+    #     root_element_id: "app-root",
+    #   }
+    #   run Rack::SinglePageApp::Template.new('assets/index.mustache', context)
+    #
+    class Template < Base
+      # @param path [String] Path to template
+      # @param context [Hash] Context object
+      def initialize(path, context)
+        template = F.read(F.expand_path(path))
+        output = ::Mustache.render(template, context)
+        super(output)
+      end
     end
   end
 end
-

--- a/test/spec_rack_single_page_app.rb
+++ b/test/spec_rack_single_page_app.rb
@@ -1,17 +1,33 @@
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/single_page_app'
+require 'mustache'
 
-describe "Rack::SinglePageApp" do
+describe Rack::SinglePageApp do
 
   specify "should render the file at the given path for all requests" do
     app = Rack::Builder.new do
       use Rack::Lint
-      run Rack::SinglePageApp.new('test/statics/index.html')
+      run Rack::SinglePageApp::Index.new('test/statics/index.html')
     end
+
     response = Rack::MockRequest.new(app).get('/')
     response.body.must_equal("My Lovely Horse\n")
     response.status.must_equal(200)
   end
 
+  specify "should render the template with given context values" do
+    context = {
+      title: "My Lovely Horse"
+    }
+
+    app = Rack::Builder.new do
+      use Rack::Lint
+      run Rack::SinglePageApp::Template.new('test/statics/template.html', context)
+    end
+
+    response = Rack::MockRequest.new(app).get('/')
+    response.body.must_equal("<title>My Lovely Horse</title>\n")
+    response.status.must_equal(200)
+  end
 end

--- a/test/statics/template.html
+++ b/test/statics/template.html
@@ -1,0 +1,1 @@
+<title>{{title}}</title>


### PR DESCRIPTION
Split the base app constructor into `::Index` and `::Template` classes and render the template when the Rack middleware stack is constructed.

The template uses Mustache and can be populated by passing in a context object. Aside from that, it works exactly the same as the regular static index.

This feature is useful for generating custom HTML content when the app starts up, such as links and scripts with cache-busting hash strings.
